### PR TITLE
Add option to maximize the window after the preview closes.

### DIFF
--- a/doc/supertab.txt
+++ b/doc/supertab.txt
@@ -27,6 +27,7 @@ Supertab                                    *supertab*
     Preselecting the first entry            |supertab-longesthighlight|
     Mapping <cr> to end completion          |supertab-crmapping|
     Auto close the preview window           |supertab-closepreviewonpopupclose|
+    Maximize window after preview close     |supertab-supertabmaximizeonclosepreview|
     Completion Chaining                     |supertab-completionchaining|
 
 ==============================================================================
@@ -315,6 +316,13 @@ g:SuperTabClosePreviewOnPopupClose (default value: 0)
 
 When enabled, supertab will attempt to close vim's completion preview window
 when the completion popup closes (completion is finished or canceled).
+
+Maximize window after preview close     *supertab-supertabmaximizeonclosepreview*
+                                        *g:SuperTabMaximizeOnClosePreview*
+
+g:SuperTabMaximizeOnClosePreview (default value: 0)
+When enabled, supertab will maximize the current window
+after the preview closes.
 
 Completion Chaining                  *supertab-completionchaining*
 

--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -131,6 +131,10 @@ set cpo&vim
     let g:SuperTabClosePreviewOnPopupClose = 0
   endif
 
+  if !exists("g:SuperTabMaximizeOnClosePreview")
+    let g:SuperTabMaximizeOnClosePreview = 0
+  endif
+
   if !exists("g:SuperTabUndoBreak")
     let g:SuperTabUndoBreak = 0
   endif
@@ -555,6 +559,9 @@ function! s:ClosePreview() " {{{
     endfor
     if preview
       pclose
+      if g:SuperTabMaximizeOnClosePreview
+        wincmd _
+      endif
     endif
     unlet b:supertab_close_preview
   endif


### PR DESCRIPTION
Hi ervandew, I needed an auto maximize window option and added it.
If you find it usefull plese pull from me.
Thanks for the plugin, by the way :)

Some (me included) use the horizontal split maximized most of the
time. This option saves the tedious <C-W> _ after each preview closing.
Default is off.
