### PR TITLE
Prevent completion using a funcref

### DIFF
--- a/doc/supertab.txt
+++ b/doc/supertab.txt
@@ -212,11 +212,18 @@ g:SuperTabNoCompleteBefore (default value: [])
 g:SuperTabNoCompleteAfter (default value: ['^', '\s'])
 
 These two variables are used to control when supertab will attempt completion
-or instead fall back to inserting a literal <tab>, by specifying a list of
-patterns which are tested against the text before and after the current cursor
-position that when matched, prevent completion. So if you don't want supertab
-to start completion at the start of a line, after a comma, or after a space,
-you can set g:SuperTabNoCompleteAfter to ['^', ',', '\s'].
+or instead fall back to inserting a literal <tab>. There are two possible ways
+to define these variables:
+
+  1) by specifying a list of patterns which are tested against the text before 
+  and after the current cursor position that when matched, prevent completion. 
+  So if you don't want supertab to start completion at the start of a line, 
+  after a comma, or after a space, you can set g:SuperTabNoCompleteAfter 
+  to ['^', ',', '\s'].
+
+  2) by specifying a funcref to a global accessible function which expects
+  as parameter the text to be inspected (before or after) and, based on that (or 
+  other factors), it returns 1 if completion must be prevented, 0 otherwise.
 
 Note: That a buffer local version of these variables
 (b:SuperTabNoCompleteBefore, b:SuperTabNoCompleteAfter) is also supported

--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -493,20 +493,34 @@ function! s:WillComplete() " {{{
 
   " honor SuperTabNoCompleteAfter
   let pre = cnum >= 2 ? line[:cnum - 2] : ''
-  for pattern in b:SuperTabNoCompleteAfter
-    if pre =~ pattern . '$'
-      return 0
-    endif
-  endfor
+  let complAfterType = type(b:SuperTabNoCompleteAfter)
+  if complAfterType == 3
+    " the option was provided as a list of patterns
+    for pattern in b:SuperTabNoCompleteAfter
+      if pre =~ pattern . '$'
+        return 0
+      endif
+    endfor
+  elseif complAfterType == 2
+    " the option was provided as a funcref
+    return !b:SuperTabNoCompleteAfter(pre)
+  endif
 
   " honor SuperTabNoCompleteBefore
   " Within a word, but user does not have mid word completion enabled.
   let post = line[cnum - 1:]
-  for pattern in b:SuperTabNoCompleteBefore
-    if post =~ '^' . pattern
-      return 0
-    endif
-  endfor
+  let complBeforeType = type(b:SuperTabNoCompleteBefore)
+  if complBeforeType == 3
+    " a list of patterns
+    for pattern in b:SuperTabNoCompleteBefore
+      if post =~ '^' . pattern
+        return 0
+      endif
+    endfor
+  elseif complBeforeType == 2
+    " the option was provided as a funcref
+    return !b:SuperTabNoCompleteAfter(post)
+  endif
 
   return 1
 endfunction " }}}


### PR DESCRIPTION
Sometimes, providing just a pattern is not enough to prevent completion. For example, in PLSQL, for function arguments, we may have:

```
dbms_stats.gather_schema_stats(ownname => user,
  |<- completion should be possible
);
|<- here completion should be prevented
```

Providing a pattern is useless in these scenarios where the logic of determining if the completion should be allowed or not is much more complex. In Vorax for example (which is a vim IDE for Oracle), I parse the statement and, based on that, I can figure out if I must provide argument completion on the current cursor position or not. But this involves using a parser and looking at more than the current line. 

This patch addresses this kind of scenarios. 
