### PR TITLE
Add function to allow external calls

### DIFF
--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -879,6 +879,10 @@ endfunction " }}}
   endif
 " }}}
 
+fu! supertab#call(func, ...)
+	retu call(a:func, a:000)
+endf
+
 call s:Init()
 
 function! TestSuperTabCodeComplete(findstart, base) " {{{


### PR DESCRIPTION
Add function to allow function calls inside SuperTab scope. This can be useful when you need to use direct function call and you cant use `<Plug>` mapping. Also it can be useful for writing extensions.

Basic usage:

``` vim
cal supertab#call('s:SuperTab', 'n')
```
