### PR TITLE
install and uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,9 @@ dist:
 
 clean:
 	@rm -R build 2> /dev/null || true
+
+install: supertab.vmb
+	vim $< -c 'so %' -c 'q'
+
+uninstall:
+	vim -c 'RmVimball supertab.vmb' -c 'q'


### PR DESCRIPTION
Just a case of usability: if we already use vim binary to make a distball, why can't we use it to install automatically?
