### PR TITLE
SuperTabCodeComplete: handle dict return value from Func

### DIFF
--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -818,11 +818,18 @@ function! SuperTabCodeComplete(findstart, base) " {{{
   endif
 
   let results = Func(a:findstart, a:base)
-  if len(results)
+  " Handle dict case, with 'words' and 'refresh' (optional).
+  " This is used by YouCompleteMe. (See complete-functions).
+  if type(results) == type({}) && has_key(results, 'words')
+    if len(results.words)
+      return results
+    endif
+  elseif len(results)
     return results
   endif
 
   exec 'let keys = "' . escape(b:SuperTabChain[1], '<') . '"'
+  " <c-e>: stop completion and go back to the originally typed text.
   call feedkeys("\<c-e>" . keys, 'nt')
   return []
 endfunction " }}}


### PR DESCRIPTION
If the first function in the chain returns a dict, instead of just a
list of words, look at (the length of) results.words.

NOTE: if results.refresh is set to "always" (as with YouCompleteMe), we
might want to return the empty list anyway, which would allow the
function to stay in the loop.

> || (has_key(results, 'refresh') && results.refresh == 'always')
