### PR TITLE
better file / tag management

### DIFF
--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -801,11 +801,10 @@ function! s:ContextText() " {{{
     let cnum = col('.')
     let synname = synIDattr(synID(line('.'), cnum - 1, 1), 'name')
 
-    if curline =~ '.*</\w*\%' . cnum . 'c' &&
-      \ (&ft == 'xml' || &ft == 'html')
+    if curline =~ '.*</\w*\%' . cnum . 'c' && &omnifunc != ''
       return "\<c-x>\<c-o>"
 
-    elseif curline =~ '.*[^<]/\w*\%' . cnum . 'c' ||
+    elseif curline =~ '\(^\|[^<]\)/\w*\%' . cnum . 'c' ||
       \ ((has('win32') || has('win64')) && curline =~ '.*\\\w*\%' . cnum . 'c')
       return "\<c-x>\<c-f>"
 


### PR DESCRIPTION
I've noticed that when closing a tag (with the cursor after a "</"), supertab triggers file completion:

![screen shot 2014-08-19 at 19 54 34](https://cloud.githubusercontent.com/assets/6401008/3971261/f9ac325c-27d1-11e4-9d92-6db8942d44c0.png)

I've tried to improve the plugin so that it now closes the tag through omnifunc, while still triggering file completion when appropriate. I'm a vimscript newbie, so I'm not sure my changes are correct, but it seems they are working :)

this is my supertab configuration for reference:

```
let g:SuperTabDefaultCompletionType = 'context'

autocmd FileType *
            \ if &omnifunc != '' |
            \     call SuperTabChain(&omnifunc, "<c-p>") |
            \ endif
```
