### PR TITLE
Not map <c-x> if already mapped to something else

### DIFF
--- a/doc/supertab.txt
+++ b/doc/supertab.txt
@@ -315,6 +315,8 @@ something that is supported. Alternatively, you can escape the <tab> with
 Enhanced longest match support      *supertab-longestenhanced*
                                     *g:SuperTabLongestEnhanced*
 
+g:SuperTabMappingTabManual (default value: <c-x>)
+
 g:SuperTabLongestEnhanced (default value: 0)
 
 When enabled and 'longest' is in your |completeopt| setting, supertab will

--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -70,6 +70,10 @@ set cpo&vim
 
 " Global Variables {{{
 
+  if !exists("g:SuperTabMappingTabManual")
+      let g:SuperTabMappingTabManual='<c-x>'
+  endif
+
   if !exists("g:SuperTabDefaultCompletionType")
     let g:SuperTabDefaultCompletionType = "<c-p>"
   endif
@@ -905,7 +909,9 @@ endfunction " }}}
   " map a regular tab to ctrl-tab (note: doesn't work in console vim)
   exec 'inoremap ' . g:SuperTabMappingTabLiteral . ' <tab>'
 
-  imap <silent> <c-x> <c-r>=<SID>ManualCompletionEnter()<cr>
+  if !hasmapto("<c-x>")
+      exec 'inoremap <silent> ' . g:SuperTabMappingTabManual . ' <c-r>=<SID>ManualCompletionEnter()<cr>'
+  endif
 
   imap <script> <Plug>SuperTabForward <c-r>=SuperTab('n')<cr>
   imap <script> <Plug>SuperTabBackward <c-r>=SuperTab('p')<cr>

--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -70,6 +70,10 @@ set cpo&vim
 
 " Global Variables {{{
 
+  if !exists("g:SuperTabMappingTabManual")
+      let g:SuperTabMappingTabManual='<c-x>'
+  endif
+
   if !exists("g:SuperTabDefaultCompletionType")
     let g:SuperTabDefaultCompletionType = "<c-p>"
   endif
@@ -905,7 +909,9 @@ endfunction " }}}
   " map a regular tab to ctrl-tab (note: doesn't work in console vim)
   exec 'inoremap ' . g:SuperTabMappingTabLiteral . ' <tab>'
 
-  imap <silent> <c-x> <c-r>=<SID>ManualCompletionEnter()<cr>
+  if !hasmapto( g:SuperTabMappingTabManual , 'i')
+      exec 'inoremap <silent> ' . g:SuperTabMappingTabManual . ' <c-r>=<SID>ManualCompletionEnter()<cr>'
+  endif
 
   imap <script> <Plug>SuperTabForward <c-r>=SuperTab('n')<cr>
   imap <script> <Plug>SuperTabBackward <c-r>=SuperTab('p')<cr>


### PR DESCRIPTION
I am using <c-x> as cut like every other editor. In insertion mode, this mapping will cut the word under cursor. Unfortunately your plugin will automatically remap <c-x> to execute ManualCompletionEnter(). I added some code to avoid this mapping is <c-x> is already user mapped. I also added a g:SuperTabMappingTabManual to let the user choose its own <c-x> mapping. 
