### PR TITLE
Silence the forward and backward mapping

### DIFF
--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -1008,8 +1008,8 @@ endfunction " }}}
     endif
   endif
 
-  exec 'imap ' . g:SuperTabMappingForward . ' <Plug>SuperTabForward'
-  exec 'imap ' . g:SuperTabMappingBackward . ' <Plug>SuperTabBackward'
+  exec 'imap <silent> ' . g:SuperTabMappingForward . ' <Plug>SuperTabForward'
+  exec 'imap <silent> ' . g:SuperTabMappingBackward . ' <Plug>SuperTabBackward'
 
   if g:SuperTabCrMapping
     let expr_map = 0


### PR DESCRIPTION
This PR fixes the flickering of the `-- INSERT --` when tabbing through the completion popup.

Thank you for a very useful plugin!
