### PR TITLE
Only unlet b:supertab_close_preview if it exists

### DIFF
--- a/plugin/supertab.vim
+++ b/plugin/supertab.vim
@@ -752,8 +752,8 @@ function! s:ClosePreview() " {{{
         " ignore: no autocmds defined
       endtry
     endif
+    unlet b:supertab_close_preview
   endif
-  silent! unlet b:supertab_close_preview
 endfunction " }}}
 
 function! s:ReleaseKeyPresses() " {{{


### PR DESCRIPTION
This change fixes a problem where Vim 7.3 would exit with a non-zero
code when `g:SuperTabClosePreviewOnPopupClose` is 1.  I see no reason
why `b:supertab_close_preview` should be unlet silently if it has
already been determined that it doesn't exist.  In addition, I removed
the `silent!` part since it is no longer needed.