### PR TITLE
Explain how to prevent completion after certain chars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ Frequently Asked Questions
 
 - **How to prevent Supertab from completing after certain characters?**
 
-  Please use the `g:SuperTabNoCompleteAfter` functionality like this:
+  Please use the `g:SuperTabNoCompleteAfter` functionality. You can add a line like this to your .vimrc
 
   ::
     let g:SuperTabNoCompleteAfter = ['^', '\s', '0', '1', '2', '3', '4', '5', '6', '7', '8', '0', '*', '-', '+', '/']

--- a/README.rst
+++ b/README.rst
@@ -170,3 +170,10 @@ Frequently Asked Questions
   agree with his finding) that while coding, the keyword match you want is
   typically the closer of the matches above the cursor, which `<c-p>` naturally
   provides.
+
+- **How to prevent Supertab from completing after certain characters?**
+
+  Please use the `g:SuperTabNoCompleteAfter` functionality like this:
+
+  ::
+    let g:SuperTabNoCompleteAfter = ['^', '\s', '0', '1', '2', '3', '4', '5', '6', '7', '8', '0', '*', '-', '+', '/']


### PR DESCRIPTION
Added a bulletpoint to the README.rst FAQ section about how to use g:SuperTabNoCompleteAfter to ignore any character.